### PR TITLE
modify time key and value to support sumo requirements

### DIFF
--- a/plugins/out_sumologic.rb
+++ b/plugins/out_sumologic.rb
@@ -116,9 +116,9 @@ class Sumologic < Fluent::BufferedOutput
             log.strip!
           end
         when 'merge_json_log'
-          log = dump_log(merge_json_log({:time => time}.merge(record)))
+          log = dump_log(merge_json_log({:timestamp => (time*1000).to_s}.merge(record)))
         else
-          log = dump_log({:time => time}.merge(record))
+          log = dump_log({:timestamp => (time*1000).to_s}.merge(record))
       end
 
       unless log.nil?


### PR DESCRIPTION
Thanks for writing this plugin. It's the only fluentd output plugin for sumologic that actually seems to work.

I've been working with sumologic over the past day to determine why their platform is not parsing the timestamp properly from our messages. It turns out that sumologic has some very specific requirements regarding the parsing of unix epoch timestamps. If the message is passed to sumologic in JSON and it contains a unix epoch time, this time must be stored in a key called "timestamp". Additionally, the unix epoch time must be a 13-digit (milliseconds) value. 

My code approach feels a little brute force and it may break when the next version of fluent is released because fluent will support milliseconds natively. Perhaps a ruby dev could suggest a better way to handle this. 